### PR TITLE
Extended Android's DefaultPushNotificationHandler behavior

### DIFF
--- a/src/Plugin.PushNotification.Android/PushNotificationManager.cs
+++ b/src/Plugin.PushNotification.Android/PushNotificationManager.cs
@@ -11,6 +11,7 @@ using Firebase.Messaging;
 using Firebase;
 using Android.Content.PM;
 using System.Collections.ObjectModel;
+using Android.Graphics;
 
 namespace Plugin.PushNotification
 {
@@ -34,6 +35,7 @@ namespace Plugin.PushNotification
         public static string NotificationContentDataKey { get; set; }
         public static int IconResource { get; set; }
         public static Android.Net.Uri SoundUri { get; set; }
+        public static Color? Color { get; set; }
         
         static Context _context;
         public static void ProcessIntent(Intent intent, bool enableDelayedResponse = true)


### PR DESCRIPTION
• Added Color property to Android's PushNotificationManager
• Added support for setting notification Color using the PushNotificationManager's setting or based on the push message content
• Added OnBuildNotification hook to the DefaultPushNotificationHandler so it can easily be extended and modified while supporting the default behavior