### PR TITLE
Added Android localized body and title support

### DIFF
--- a/src/Plugin.PushNotification.Abstractions/IPushNotification.cs
+++ b/src/Plugin.PushNotification.Abstractions/IPushNotification.cs
@@ -77,9 +77,9 @@ namespace Plugin.PushNotification.Abstractions
 
     public class PushNotificationDataEventArgs : EventArgs
     {
-        public IDictionary<string, string> Data { get; }
+        public IDictionary<string, object> Data { get; }
 
-        public PushNotificationDataEventArgs(IDictionary<string, string> data)
+        public PushNotificationDataEventArgs(IDictionary<string, object> data)
         {
             Data = data;
         }
@@ -93,11 +93,11 @@ namespace Plugin.PushNotification.Abstractions
     {
         public string Identifier { get; }
 
-        public IDictionary<string, string> Data { get; }
+        public IDictionary<string, object> Data { get; }
 
         public NotificationCategoryType Type { get; }
 
-        public PushNotificationResponseEventArgs(IDictionary<string, string> data, string identifier = "", NotificationCategoryType type = NotificationCategoryType.Default)
+        public PushNotificationResponseEventArgs(IDictionary<string, object> data, string identifier = "", NotificationCategoryType type = NotificationCategoryType.Default)
         {
             Identifier = identifier;
             Data = data;

--- a/src/Plugin.PushNotification.Abstractions/IPushNotificationHandler.cs
+++ b/src/Plugin.PushNotification.Abstractions/IPushNotificationHandler.cs
@@ -11,6 +11,6 @@ namespace Plugin.PushNotification.Abstractions
         //Method triggered when a notification is opened
         void OnOpened(NotificationResponse response);
         //Method triggered when a notification is received
-        void OnReceived(IDictionary<string, string> parameters);
+        void OnReceived(IDictionary<string, object> parameters);
     }
 }

--- a/src/Plugin.PushNotification.Abstractions/NotificationResponse.cs
+++ b/src/Plugin.PushNotification.Abstractions/NotificationResponse.cs
@@ -8,11 +8,11 @@ namespace Plugin.PushNotification.Abstractions
     {
         public string Identifier { get; }
 
-        public IDictionary<string, string> Data { get; }
+        public IDictionary<string, object> Data { get; }
 
         public NotificationCategoryType Type { get; }
 
-        public NotificationResponse(IDictionary<string, string> data, string identifier = "", NotificationCategoryType type = NotificationCategoryType.Default)
+        public NotificationResponse(IDictionary<string, object> data, string identifier = "", NotificationCategoryType type = NotificationCategoryType.Default)
         {
             Identifier = identifier;
             Data = data;

--- a/src/Plugin.PushNotification.Android/PNMessagingService.cs
+++ b/src/Plugin.PushNotification.Android/PNMessagingService.cs
@@ -19,15 +19,29 @@ namespace Plugin.PushNotification
     {
         public override void OnMessageReceived(RemoteMessage message)
         {
-            IDictionary<string, string> parameters = new Dictionary<string, string>();
+            var parameters = new Dictionary<string, object>();
             var notification = message.GetNotification();
             if (notification != null)
             {
                 if (!string.IsNullOrEmpty(notification.Body))
                     parameters.Add("body", notification.Body);
 
+                if (!string.IsNullOrEmpty(notification.BodyLocalizationKey))
+                    parameters.Add("body_loc_key", notification.BodyLocalizationKey);
+
+                var bodyLocArgs = notification.GetBodyLocalizationArgs();
+                if (bodyLocArgs != null && bodyLocArgs.Any())
+                    parameters.Add("body_loc_args", bodyLocArgs);
+
                 if (!string.IsNullOrEmpty(notification.Title))
                     parameters.Add("title", notification.Title);
+
+                if (!string.IsNullOrEmpty(notification.TitleLocalizationKey))
+                    parameters.Add("title_loc_key", notification.TitleLocalizationKey);
+
+                var titleLocArgs = notification.GetTitleLocalizationArgs();
+                if (titleLocArgs != null && titleLocArgs.Any())
+                    parameters.Add("title_loc_args", titleLocArgs);
 
                 if (!string.IsNullOrEmpty(notification.Tag))
                     parameters.Add("tag", notification.Tag);

--- a/src/Plugin.PushNotification.Android/PushNotificationActionReceiver.cs
+++ b/src/Plugin.PushNotification.Android/PushNotificationActionReceiver.cs
@@ -17,7 +17,7 @@ namespace Plugin.PushNotification
     {
         public override void OnReceive(Context context, Intent intent)
         {
-            IDictionary<string, string> parameters = new Dictionary<string, string>();
+            IDictionary<string, object> parameters = new Dictionary<string, object>();
             var extras = intent.Extras;
 
             if (extras != null && !extras.IsEmpty)

--- a/src/Plugin.PushNotification.Android/PushNotificationManager.cs
+++ b/src/Plugin.PushNotification.Android/PushNotificationManager.cs
@@ -43,15 +43,11 @@ namespace Plugin.PushNotification
             Bundle extras = intent?.Extras;
             if (extras != null && !extras.IsEmpty)
             {
-
-                var parameters = new Dictionary<string, string>();
-
+                var parameters = new Dictionary<string, object>();
                 foreach (var key in extras.KeySet())
                 {
                     if (!parameters.ContainsKey(key) && extras.Get(key) != null)
-                    {
                         parameters.Add(key, $"{extras.Get(key)}");
-                    }
                 }
 
                 NotificationManager manager = _context.GetSystemService(Context.NotificationService) as NotificationManager;
@@ -59,38 +55,29 @@ namespace Plugin.PushNotification
                 if (notificationId != -1)
                 {
                     var notificationTag = extras.GetString(DefaultPushNotificationHandler.ActionNotificationTagKey, string.Empty);
-
                     if (notificationTag == null)
                         manager.Cancel(notificationId);
                     else
                         manager.Cancel(notificationTag, notificationId);
-
                 }
 
 
                 var response = new NotificationResponse(parameters, extras.GetString(DefaultPushNotificationHandler.ActionIdentifierKey, string.Empty));
 
                 if (_onNotificationOpened == null && enableDelayedResponse)
-                {
                     delayedNotificationResponse = response;
-                }
                 else
-                {
                     _onNotificationOpened?.Invoke(CrossPushNotification.Current, new PushNotificationResponseEventArgs(response.Data, response.Identifier, response.Type));
-                }
-
 
                 CrossPushNotification.Current.NotificationHandler?.OnOpened(response);
-
             }
         }
+
         public static void Initialize(Context context, bool resetToken)
         {
             FirebaseApp.InitializeApp(context);
-
      
             _context = context;
-
 
             CrossPushNotification.Current.NotificationHandler = CrossPushNotification.Current.NotificationHandler ?? new DefaultPushNotificationHandler();
 
@@ -291,7 +278,7 @@ namespace Plugin.PushNotification
         {
             _onTokenRefresh?.Invoke(CrossPushNotification.Current, new PushNotificationTokenEventArgs(token));
         }
-        internal static void RegisterData(IDictionary<string, string> data)
+        internal static void RegisterData(IDictionary<string, object> data)
         {
             _onNotificationReceived?.Invoke(CrossPushNotification.Current, new PushNotificationDataEventArgs(data));
         }

--- a/src/Plugin.PushNotification.iOS/DefaultPushNotificationHandler.cs
+++ b/src/Plugin.PushNotification.iOS/DefaultPushNotificationHandler.cs
@@ -19,7 +19,7 @@ namespace Plugin.PushNotification
             System.Diagnostics.Debug.WriteLine($"{DomainTag} - OnOpened");
         }
 
-        public void OnReceived(IDictionary<string, string> parameters)
+        public void OnReceived(IDictionary<string, object> parameters)
         {
             System.Diagnostics.Debug.WriteLine($"{DomainTag} - OnReceived");
         }

--- a/src/Plugin.PushNotification.iOS/PushNotificationManager.cs
+++ b/src/Plugin.PushNotification.iOS/PushNotificationManager.cs
@@ -260,9 +260,9 @@ namespace Plugin.PushNotification
             _onNotificationError?.Invoke(CrossPushNotification.Current, new PushNotificationErrorEventArgs(error.Description));
         }
 
-        static IDictionary<string, string> GetParameters(NSDictionary data)
+        static IDictionary<string, object> GetParameters(NSDictionary data)
         {
-            var parameters = new Dictionary<string, string>();
+            var parameters = new Dictionary<string, object>();
 
             var keyAps = new NSString("aps");
             var keyAlert = new NSString("alert");


### PR DESCRIPTION
• Modified plugin setup to use a dictionary of string to object for the parameters since Android supports non-string data types as well
• Updated Android's PNMessagingService so it also extracts the body and title localization key and corresponding arguments
• Updated Android's DefaultPushNotificationHandler so it has built in support for localized body and title based on the notification's key and arguments