### PR TITLE
Support getting device token in iOS 13

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -157,7 +157,22 @@ Also should override these methods and make the following calls:
 ```csharp
         public override void RegisteredForRemoteNotifications(UIApplication application, NSData deviceToken)
         {
-             PushNotificationManager.DidRegisterRemoteNotifications(deviceToken);
+            // If iOS SDK version is 13 or above
+            byte[] result = new byte[deviceToken.Length];
+            System.Runtime.InteropServices.Marshal.Copy(deviceToken.Bytes, result, 0, (int)deviceToken.Length);
+            var token = BitConverter.ToString(result).Replace("-", "");
+            
+            // If iOS SDK version is 12 or below
+            //string trimmedDeviceToken = deviceToken.Description;
+            //if (!string.IsNullOrWhiteSpace(trimmedDeviceToken))
+            //{
+            //    trimmedDeviceToken = trimmedDeviceToken.Trim('<');
+            //    trimmedDeviceToken = trimmedDeviceToken.Trim('>');
+            //    trimmedDeviceToken = trimmedDeviceToken.Trim();
+            //    trimmedDeviceToken = trimmedDeviceToken.Replace(" ", "");
+            //}
+            
+            PushNotificationManager.DidRegisterRemoteNotifications(token);
         }
 
         public override void FailedToRegisterForRemoteNotifications(UIApplication application, NSError error)

--- a/src/Plugin.PushNotification.iOS/PushNotificationManager.cs
+++ b/src/Plugin.PushNotification.iOS/PushNotificationManager.cs
@@ -262,18 +262,10 @@ namespace Plugin.PushNotification
             completionHandler();
         }
 
-        public static void DidRegisterRemoteNotifications(NSData deviceToken)
+        public static void DidRegisterRemoteNotifications(string token)
         {
-            string trimmedDeviceToken = deviceToken.Description;
-            if (!string.IsNullOrWhiteSpace(trimmedDeviceToken))
-            {
-                trimmedDeviceToken = trimmedDeviceToken.Trim('<');
-                trimmedDeviceToken = trimmedDeviceToken.Trim('>');
-                trimmedDeviceToken = trimmedDeviceToken.Trim();
-                trimmedDeviceToken = trimmedDeviceToken.Replace(" ", "");
-            }
-            NSUserDefaults.StandardUserDefaults.SetString(trimmedDeviceToken, TokenKey);
-            _onTokenRefresh?.Invoke(CrossPushNotification.Current, new PushNotificationTokenEventArgs(trimmedDeviceToken));
+            NSUserDefaults.StandardUserDefaults.SetString(token, TokenKey);
+            _onTokenRefresh?.Invoke(CrossPushNotification.Current, new PushNotificationTokenEventArgs(token));
         }
 
         public static void DidReceiveMessage(NSDictionary data)


### PR DESCRIPTION
This PR supports getting device token in iOS 13.

Due to the way of getting device token is now iOS SDK version dependent, I could only find a way to support both by moving the SDK version specific code to `AppDelegate.cs`.

This will fix https://github.com/CrossGeeks/PushNotificationPlugin/issues/115

Thanks to this StackOverflow post as well: https://stackoverflow.com/a/58028222/78578