### PR TITLE
Fixed where the Token wasn't being set when it was registered for iOS

### DIFF
--- a/src/Plugin.PushNotification/PushNotificationManager.apple.cs
+++ b/src/Plugin.PushNotification/PushNotificationManager.apple.cs
@@ -285,7 +285,7 @@ namespace Plugin.PushNotification
             }
 
             var cleanedDeviceToken = hex.ToString();
-            Token = cleanedDeviceToken;
+            InternalSaveToken(cleanedDeviceToken);
             _onTokenRefresh?.Invoke(CrossPushNotification.Current, new PushNotificationTokenEventArgs(cleanedDeviceToken));
         }
 

--- a/src/Plugin.PushNotification/PushNotificationManager.apple.cs
+++ b/src/Plugin.PushNotification/PushNotificationManager.apple.cs
@@ -285,6 +285,7 @@ namespace Plugin.PushNotification
             }
 
             var cleanedDeviceToken = hex.ToString();
+            Token = cleanedDeviceToken;
             _onTokenRefresh?.Invoke(CrossPushNotification.Current, new PushNotificationTokenEventArgs(cleanedDeviceToken));
         }
 


### PR DESCRIPTION
The token was being notified that it had changed.

However, the token wasn't being saved in iOS once it updated, only the event handler was being fired.