### PR TITLE
Fix for TOO_MANY_REGISTRATIONS crashes reported by some Google Console Pre-launch tests

### DIFF
--- a/src/Plugin.PushNotification/Plugin.PushNotification.csproj
+++ b/src/Plugin.PushNotification/Plugin.PushNotification.csproj
@@ -35,6 +35,7 @@
     <Authors>Rendy Del Rosario, Sameer Khandekar, Px7-941</Authors>
     <Copyright>Copyright 2017 CrossGeeks</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageVersion>3.0.25-custom</PackageVersion>
   </PropertyGroup>
 
     <!-- Define what happens on build and release -->

--- a/src/Plugin.PushNotification/PushNotificationManager.android.cs
+++ b/src/Plugin.PushNotification/PushNotificationManager.android.cs
@@ -361,8 +361,12 @@ namespace Plugin.PushNotification
 
         public void OnComplete(Android.Gms.Tasks.Task task)
         {
-            string token = task.Result.JavaCast<IInstanceIdResult>().Token;
-            _tokenTcs?.TrySetResult(token);
+            try
+            {
+                string token = task.Result.JavaCast<IInstanceIdResult>().Token;
+                _tokenTcs?.TrySetResult(token);
+            }
+            catch { }            
         }
 
         public void ClearAllNotifications()


### PR DESCRIPTION
Added error handling in the OnComplete event (Android). This is needed because Google Play Console Pre-Launch tests (reports) indicate crashes on some test devices. Crashes seem to be caused by an error on getting a push token, some of these test devices (2/12 in our case) will return error TOO_MANY_REGISTRATIONS and lead to a FATAL CRASH.

The error handling is not absolutely needed for real-life devices, but will help prevent the TOO_MANY_REGISTRATIONS issue with Google Play Console automated tests and Firebase test lab.

See partial logcat below. With the error handling applied these fatal crashes are gone, and everything works as expected.

`01-21 14:40:25.471: I/MonoDroid(26121): Java.Lang.RuntimeException: java.io.IOException: TOO_MANY_REGISTRATIONS ---> Java.IO.IOException: TOO_MANY_REGISTRATIONS
01-21 14:40:25.471: I/MonoDroid(26121):    --- End of inner exception stack trace ---
01-21 14:40:25.471: I/MonoDroid(26121):   at Java.Interop.JniEnvironment+InstanceMethods.CallObjectMethod (Java.Interop.JniObjectReference instance, Java.Interop.JniMethodInfo method, Java.Interop.JniArgumentValue* args) [0x00069] in <614ad52f6a494789ad8ed4ef621602d6>:0 
01-21 14:40:25.471: I/MonoDroid(26121):   at Java.Interop.JniPeerMembers+JniInstanceMethods.InvokeAbstractObjectMethod (System.String encodedMember, Java.Interop.IJavaPeerable self, Java.Interop.JniArgumentValue* parameters) [0x00014] in <614ad52f6a494789ad8ed4ef621602d6>:0 
01-21 14:40:25.471: I/MonoDroid(26121):   at Android.Gms.Tasks.TaskInvoker.get_RawResult () [0x0000a] in <c5017cb2f56f4433a847567e06806cfa>:0 
01-21 14:40:25.471: I/MonoDroid(26121):   at Android.Gms.Tasks.Task.get_Result () [0x00000] in <c5017cb2f56f4433a847567e06806cfa>:0 
01-21 14:40:25.471: I/MonoDroid(26121):   at Plugin.PushNotification.PushNotificationManager.OnComplete (Android.Gms.Tasks.Task task) [0x00000] in <0a77df87120a45bda9b2913534e024b6>:0 
01-21 14:40:25.471: I/MonoDroid(26121):   at Android.Gms.Tasks.IOnCompleteListenerInvoker.n_OnComplete_Lcom_google_android_gms_tasks_Task_ (System.IntPtr jnienv, System.IntPtr native__this, System.IntPtr native_task) [0x0000f] in <c5017cb2f56f4433a847567e06806cfa>:0 
01-21 14:40:25.471: I/MonoDroid(26121):   at (wrapper dynamic-method) Android.Runtime.DynamicMethodNameCounter.13(intptr,intptr,intptr)
01-21 14:40:25.471: I/MonoDroid(26121):   --- End of managed Java.Lang.RuntimeException stack trace ---
01-21 14:40:25.471: I/MonoDroid(26121): com.google.android.gms.tasks.RuntimeExecutionException: java.io.IOException: TOO_MANY_REGISTRATIONS
01-21 14:40:25.471: I/MonoDroid(26121): 	at com.google.android.gms.tasks.zzu.getResult(Unknown Source:21)
01-21 14:40:25.471: I/MonoDroid(26121): 	at md53da296b4b9f7aa6e187dc28cf9fd28f3.PushNotificationManager.n_onComplete(Native Method)
01-21 14:40:25.471: I/MonoDroid(26121): 	at md53da296b4b9f7aa6e187dc28cf9fd28f3.PushNotificationManager.onComplete(Unknown Source:0)
01-21 14:40:25.471: I/MonoDroid(26121): 	at com.google.android.gms.tasks.zzj.run(Unknown Source:23)
01-21 14:40:25.471: I/MonoDroid(26121): 	at android.os.Handler.handleCallback(Handler.java:789)
01-21 14:40:25.471: I/MonoDroid(26121): 	at android.os.Handler.dispatchMessage(Handler.java:98)
01-21 14:40:25.471: I/MonoDroid(26121): 	at android.os.Looper.loop(Looper.java:164)
01-21 14:40:25.471: I/MonoDroid(26121): 	at android.app.ActivityThread.main(ActivityThread.java:6938)
01-21 14:40:25.471: I/MonoDroid(26121): 	at java.lang.reflect.Method.invoke(Native Method)
01-21 14:40:25.471: I/MonoDroid(26121): 	at com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:327)
01-21 14:40:25.471: I/MonoDroid(26121): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1374)
01-21 14:40:25.471: I/MonoDroid(26121): Caused by: java.io.IOException: TOO_MANY_REGISTRATIONS
01-21 14:40:25.471: I/MonoDroid(26121): 	at com.google.firebase.iid.zzr.zza(Unknown Source:40)
01-21 14:40:25.471: I/MonoDroid(26121): 	at com.google.firebase.iid.zzr.zza(Unknown Source:0)
01-21 14:40:25.471: I/MonoDroid(26121): 	at com.google.firebase.iid.zzu.then(Unknown Source:10)
01-21 14:40:25.471: I/MonoDroid(26121): 	at com.google.android.gms.tasks.zzd.run(Unknown Source:26)
01-21 14:40:25.471: I/MonoDroid(26121): 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
01-21 14:40:25.471: I/MonoDroid(26121): 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
01-21 14:40:25.471: I/MonoDroid(26121): 	at java.lang.Thread.run(Thread.java:764)`