### PR TITLE
IOS: Fix NotificationActionType.Default is ignored by RegisterUserNotificationCategories

### DIFF
--- a/src/Plugin.PushNotification/PushNotificationManager.ios.cs
+++ b/src/Plugin.PushNotification/PushNotificationManager.ios.cs
@@ -199,6 +199,9 @@ namespace Plugin.PushNotification
                         // Create action
                         switch (action.Type)
                         {
+                            case NotificationActionType.Default:
+                                actions.Add(UNNotificationAction.FromIdentifier(action.Id, action.Title, UNNotificationActionOptions.None));
+                                break;
                             case NotificationActionType.AuthenticationRequired:
                                 actions.Add(UNNotificationAction.FromIdentifier(action.Id, action.Title, UNNotificationActionOptions.AuthenticationRequired));
                                 break;


### PR DESCRIPTION
`NotificationActionType.Default` cannot be used to add an action on iOS because the switch block in `RegisterUserNotificationCategories` misses the case.